### PR TITLE
Solve n+1 queries problem by eager loading associated users with scores

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.includes(:user).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: https://github.com/GeorgeMarcus/golfr_backend/issues/1

**Changes**

When feed API was requested, users associated with each score were lazy loaded. This generated a different query for each score to load it's user. Now scores eager load users on feed so users are taken at once from the database.

**Before**

<img width="955" alt="image" src="https://user-images.githubusercontent.com/94969023/143557047-4e9c529c-595a-4fe7-9b95-6e6ec69b469c.png">

**After**

<img width="961" alt="image" src="https://user-images.githubusercontent.com/94969023/143557094-b48f9055-cb5b-44cf-827a-8ed7b54397a6.png">
